### PR TITLE
pin: lock httpx to 0.27.x (avoid 0.28 proxies removal)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gunicorn==21.2.0
 
 # --- OpenAI / HTTP ---
 openai>=1.40.0,<2
-httpx==0.27.0
+httpx~=0.27.2
 requests==2.31.0
 
 # --- Vector / Data ---


### PR DESCRIPTION
Locks httpx to the latest 0.27.x release to prevent breaking changes introduced in 0.28, including the removal of the `proxies` argument.

This ensures the agent continues to run exactly as before without changes to networking behavior.
